### PR TITLE
Do not pin specific libvirt version

### DIFF
--- a/deployment_scripts/puppet/manifests/pre_deployment.pp
+++ b/deployment_scripts/puppet/manifests/pre_deployment.pp
@@ -15,9 +15,6 @@
 
 notice('MODULAR: plumgrid/pre_deployment.pp')
 
-package { 'libvirt0' :
-  ensure => '1.2.2-0ubuntu13.1.14' ,
-} ->
-package { 'libvirt-bin' :
-  ensure => '1.2.2-0ubuntu13.1.14' ,
+package { ['libvirt0', 'libvirt-bin']:
+  ensure => 'latest',
 }


### PR DESCRIPTION
The latest version of libvirt on Trusty is 1.2.2-0ubuntu13.1.16. Instead
of requiring specific version, let's try to pull the latest and hope
for the best.

Puppet doesn't have possibility to ensure the minimum given version,
unfortunately neither does apt itself.